### PR TITLE
Inspect rating deviation changes

### DIFF
--- a/all_rating.py
+++ b/all_rating.py
@@ -160,12 +160,29 @@ def process_old_results():
     hres = {os.path.basename(f)[:-12]: f for f in results}
     hrat = {os.path.basename(f)[:-12]: f for f in ratings}
     playerdb = PlayerDB()
+    player_devs = {}
+    num_inc = 0
+    num_dec = 0
+    num_same = 0
     for prefix, date in ALL:
         print(f"Reading {prefix}")
         date = datetime.strptime(date, '%Y-%m-%d')
         res = hres[prefix]
         rat = hrat[prefix]
         t = playerdb.process_one_tournament(rat, res, prefix, date)
+        for p in playerdb.players:
+            player = playerdb.players[p]
+            curr_dev = player.deviation
+            if player.name in player_devs:
+                prev_dev = player_devs[player.name]
+                if curr_dev > prev_dev:
+                    num_inc += 1
+                elif curr_dev < prev_dev:
+                    num_dec += 1
+                else:
+                    num_same += 1
+            player_devs[player.name] = curr_dev
+    print("Increases: {}\nDecreases: {}\nUnchanged: {}\n".format(num_inc, num_dec, num_same))
     return playerdb, t
 
 


### PR DESCRIPTION
Seems like all player rating deviations are monotonically decreasing. Not sure if this is the desired behavior. I'm not finding where [step 1.2 of the Taral paper](https://drive.google.com/file/d/1egZRGXSclDkgicHjRGozIPGOmbvIQ-RH/view) is being applied or if there is some minimum deviation being enforced, but could be overlooking something. This is the relevant output for the changes in this branch that inspect rating deviations.


```
...
Increases: 0
Decreases: 536
Unchanged: 5904
...
```